### PR TITLE
Remove info linking to exchanges

### DIFF
--- a/docs/Frequently-Asked-Questions.md
+++ b/docs/Frequently-Asked-Questions.md
@@ -490,7 +490,6 @@ Read a great post about the justification for it [here](https://medium.com/@turt
 There are multiple ways to acquire TRTL, for example:
 
 * Mining - see [here](guides/mining/Mining)
-* Buying - TRTL is currently available on these exchanges: [TradeOgre](https://tradeogre.com/exchange/BTC-TRTL) and [TradeSatoshi](https://tradesatoshi.com/Exchange/?market=TRTL_BTC)
 * Bounties - Bounties for developing TRTL software, spreading the word of TRTL, and many other things are often posted in the #bounties channel on [Discord][discord_link]. Check the pinned messages for current bounties.
 * Tips - Turtles with often tip each other, especially if you make spicy memes in the `#memes` channel
 * Faucet - Head over to the faucets-


### PR DESCRIPTION
We should not be linking to any exchanges, listing one means we have to list all which is a conflict of interest as it can be seen as an endorsement. We're large enough at this point for any person to be able to find some for sale if that's how they want to acquire TRTL