### PR TITLE
add section about TurtleCoind config

### DIFF
--- a/docs/guides/config/config.md
+++ b/docs/guides/config/config.md
@@ -1,0 +1,22 @@
+---
+title: TurtleCoind config
+---
+
+## How to config TurtleCoind?
+
+Run TurtleCoind with arg `--help` will print all options.
+
+TurtleCoind can start with these options by command line args, or use `-c` followed a json file for configuration.
+
+The option in config file will unwrap the front `--`, for example:
+```json
+// the config file
+{
+    "db-max-open-files": 125,
+    "db-read-buffer-size": 128,
+    "db-threads": 4,
+    "db-write-buffer-size": 256
+}
+```
+
+If you want to check the default options, use `--dump-config`.

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -47,6 +47,9 @@
       ],
       "Misc": [
          "guides/Using-trtlbot-plus-plus"
+      ],
+      "Config": [
+         "guides/config/config"
       ]
    },
    "devs": {


### PR DESCRIPTION
Add a section about TurtleCoind config.
Under the path `/guides/config/config`