### PR TITLE
Termux is deprecated in Google Play

### DIFF
--- a/docs/guides/mining/Using-Termux.md
+++ b/docs/guides/mining/Using-Termux.md
@@ -6,8 +6,7 @@ title: Mining with Termux
 
 ## Downloading and Compiling NinjaRig
 
-1. Download [Termux](https://termux.com) from the [Play Store](https://play.google.com/store/apps/details?id=com.termux) 
-   or from [F-droid](https://f-droid.org/repository/browse/?fdid=com.termux).
+1. Download [Termux](https://termux.com) from [F-droid](https://f-droid.org/repository/browse/?fdid=com.termux).
 2. Upon downloading and installing, open the app.
 3. Run `pkg upgrade -y`
 4. Run `pkg install git cmake libuv clang nano -y`

--- a/docs/guides/mining/XMRIG-Guide.md
+++ b/docs/guides/mining/XMRIG-Guide.md
@@ -40,9 +40,9 @@ Needs to be compiled. Instructions [here](https://github.com/xmrig/xmrig/wiki/OS
 2. Open the `config.json` file with Notepad
 3. Find and change the following lines:
 
-* `"algo: "argon2/chukwav2"`
-* `"url: "[pool address]"`
-* `"user: "[wallet address]"`
+* `"algo": "argon2/chukwav2"`
+* `"url": "[pool address]"`
+* `"user": "[wallet address]"`
 
 - Instead of `[wallet address]`, simply paste your TurtleCoin wallet's address. Make sure to keep the `"`!
   - If you don't have one yet, you can find out how to create a wallet [here](../wallets/Making-a-Wallet)


### PR DESCRIPTION
Remove the Google Play Store link in the `Using-Termux.md` file due to deprecation : 
 https://www.reddit.com/r/termux/comments/pkujfa/important_deprecation_notice_for_google_play/